### PR TITLE
Fix length of mattermost token

### DIFF
--- a/.config.json
+++ b/.config.json
@@ -1,6 +1,6 @@
 {
 	"host": "http://mattermost.example.com:8065",
-	"token": "9jrxak1ykxrmnaed9cps9i4cim3y5b",
+	"token": "9jrxak1ykxrmnaed9cps9i4cim",
 	"user": {
 		"id": "bot",
 		"password": "botbot"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Change parameter in `config.json` e.g.
 ```
 {
   "host": "http://mattermost.example.com:8065", # The URL of your Mattermost server
-  "token": "9jrxak1ykxrmnaed9cps9i4cim3y5b", # The Token created my Mattermost
+  "token": "9jrxak1ykxrmnaed9cps9i4cim", # The Token created my Mattermost
   "user": {
    "id": "bot",          # The username of an existing Mattermost account
    "password": "botbot"  # The password of an existing Mattermost account

--- a/poll/conf_test.go
+++ b/poll/conf_test.go
@@ -20,7 +20,7 @@ func TestReadConf(t *testing.T) {
 	if c.Host != e {
 		t.Error("LoadConf Error. Expected: %s, Actual: %s.", e, c.Host)
 	}
-	e = "9jrxak1ykxrmnaed9cps9i4cim3y5b"
+	e = "9jrxak1ykxrmnaed9cps9i4cim"
         if c.Token != e {
 		t.Error("LoadConf Error. Expected: %s, Actual: %s.", e, c.Token)
 	}

--- a/testdata/sample_conf.json
+++ b/testdata/sample_conf.json
@@ -1,6 +1,6 @@
 {
 	"host": "http://localhost:8065",
-	"token": "9jrxak1ykxrmnaed9cps9i4cim3y5b",
+	"token": "9jrxak1ykxrmnaed9cps9i4cim",
 	"user": {
 		"id": "bot",
 		"password": "botbot"


### PR DESCRIPTION
The length should be 26 characters, not 30.