### PR TITLE
Fix the file name of coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
 dist/
 config.json
-profile.out
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ clean:
 	rm -rf dist/*
 
 test:
-	go test -coverprofile=profile.out -covermode=atomic ./poll/
+	go test -coverprofile=coverage.txt -covermode=atomic ./poll/
 
 coverage: test
-	go tool cover -html=profile.out
+	go tool cover -html=coverage.txt
 
 dist: cross-build
 	cd dist && \


### PR DESCRIPTION
Codecov don't detect the coverage file named `profile.out`.
[Job \#88\.1 \- kaakaa/matterpoll\-emoji \- Travis CI](https://travis-ci.org/kaakaa/matterpoll-emoji/jobs/258029868#L620)

Fixing the file name of coverage for detected by codecov script
