### PR TITLE
Add error messanges for token missmatch & refactor tests

### DIFF
--- a/poll/poll_func.go
+++ b/poll/poll_func.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	RESPONSE_USERNAME = "Matterpoll"
-	RESPONSE_ICON_URL = "https://www.mattermost.org/wp-content/uploads/2016/04/icon.png"
+	ResponseUsername = "Matterpoll"
+	ResponseIconUrl  = "https://www.mattermost.org/wp-content/uploads/2016/04/icon.png"
 )
 
 var Conf *PollConf
@@ -32,8 +32,13 @@ func PollCmd(w http.ResponseWriter, r *http.Request) {
 	valid_poll := err == nil
 
 	var response model.CommandResponse
-	response.Username = RESPONSE_USERNAME
-	response.IconURL = RESPONSE_ICON_URL
+	response.Username = ResponseUsername
+	response.IconURL = ResponseIconUrl
+
+	if valid_poll && len(Conf.Token) != 0 && Conf.Token != poll.Token {
+		valid_poll = false
+		err = fmt.Errorf(ErrorTokenMissmatch)
+	}
 	if valid_poll {
 		response.ResponseType = model.COMMAND_RESPONSE_TYPE_IN_CHANNEL
 		response.Text = poll.Message + ` #poll`
@@ -43,11 +48,6 @@ func PollCmd(w http.ResponseWriter, r *http.Request) {
 	}
 	io.WriteString(w, response.ToJson())
 	if valid_poll {
-		if len(Conf.Token) != 0 && Conf.Token != poll.Token {
-			log.Print("Token missmatch. Check you config.json")
-			return
-		}
-
 		c := model.NewAPIv4Client(Conf.Host)
 		user, err := Login(c)
 		if err != nil {

--- a/poll/poll_func_test.go
+++ b/poll/poll_func_test.go
@@ -11,88 +11,78 @@ import (
 	"testing"
 )
 
-type Test struct {
-	Filename    string
-	Message     string
-	Emojis      string
-	CorrectPoll bool
-}
-
-func TestCommand(t *testing.T) {
+func TestCommandCorrect(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	tests := []Test{
-		// All correct
-		{"sample_conf.json", "What do you gys wanna grab for lunch?", ":pizza: :sushi:", true},
-		// Wrong message format
-		{"sample_conf.json", model.NewRandomString(20), "", false},
-		// Token missmatch
-		{"sample_conf.json", "What do you gys wanna grab for lunch?", ":pizza: :sushi:", true},
-	}
-	for i, test := range tests {
-		err := setConfig(test.Filename)
-		require.Nil(err)
-		var payload string
-		switch i {
-		// All correct
-		case 0:
-			payload = fmt.Sprintf("token=%s&user_id=%s&text=\"%s\"%s", Conf.Token, model.NewId(), test.Message, test.Emojis)
-		// Wrong message format
-		case 1:
-			payload = fmt.Sprintf("token=%s&user_id=%s&text=%s", Conf.Token, model.NewId(), test.Message)
-		// Token missmatch
-		case 2:
-			payload = fmt.Sprintf("token=%s&user_id=%s&text=\"%s\"%s", model.NewId(), model.NewId(), test.Message, test.Emojis)
-		}
-		reader := strings.NewReader(payload)
+	message := "What do you gys wanna grab for lunch?"
+	emojis := ":pizza: :sushi:"
+	err := setConfig("sample_conf.json")
+	require.Nil(err)
 
-		r, err := http.NewRequest(http.MethodPost, "localhost:8505/poll", reader)
-		require.Nil(err)
-		require.NotNil(r)
-		r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", Conf.Token, model.NewId(), message, emojis)
+	response := sendHttpRequest(require, payload)
 
-		recorder := httptest.NewRecorder()
-		PollCmd(recorder, r)
-
-		response := model.CommandResponseFromJson(recorder.Result().Body)
-		require.NotNil(response)
-		assert.Equal(response.Username, RESPONSE_USERNAME)
-		assert.Equal(response.IconURL, RESPONSE_ICON_URL)
-		if test.CorrectPoll {
-			assert.Equal(response.ResponseType, model.COMMAND_RESPONSE_TYPE_IN_CHANNEL)
-			assert.Equal(response.Text, test.Message+" #poll")
-		} else {
-			assert.Equal(response.ResponseType, model.COMMAND_RESPONSE_TYPE_EPHEMERAL)
-			assert.Equal(response.Text, error_wrong_format)
-		}
-	}
+	assert.Equal(ResponseUsername, response.Username)
+	assert.Equal(ResponseIconUrl, response.IconURL)
+	assert.Equal(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, response.ResponseType)
+	assert.Equal(message+" #poll", response.Text)
 }
 
-func TestHeader(t *testing.T) {
+func TestCommandWronMessageFormat(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	tests := []Test{
-		// All correct
-		{"sample_conf.json", "What do you gys wanna grab for lunch?", ":pizza: :sushi:", true},
-	}
-	for i, test := range tests {
-		err := setConfig(test.Filename)
-		require.Nil(err)
-		payload := fmt.Sprintf("token=%s&user_id=%s&text=\"%s\"%s", Conf.Token, model.NewId(), test.Message, test.Emojis)
-		reader := strings.NewReader(payload)
-		switch i {
-		case 0:
-			r, err := http.NewRequest("POST", "localhost:8505/poll", reader)
-			require.Nil(err)
-			require.NotNil(r)
+	message := model.NewRandomString(20)
+	emojis := ""
+	err := setConfig("sample_conf.json")
+	require.Nil(err)
 
-			recorder := httptest.NewRecorder()
-			PollCmd(recorder, r)
-			assert.Equal(recorder.Code, http.StatusUnsupportedMediaType)
-		}
-	}
+	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", model.NewId(), model.NewId(), message, emojis)
+	response := sendHttpRequest(require, payload)
+
+	assert.Equal(ResponseUsername, response.Username)
+	assert.Equal(ResponseIconUrl, response.IconURL)
+	assert.Equal(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, response.ResponseType)
+	assert.Equal(ErrorTextWrongFormat, response.Text)
+}
+
+func TestCommandTokenMissmatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	message := "What do you gys wanna grab for lunch?"
+	emojis := ":pizza: :sushi:"
+	err := setConfig("sample_conf.json")
+	require.Nil(err)
+
+	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", model.NewId(), model.NewId(), message, emojis)
+	response := sendHttpRequest(require, payload)
+
+	assert.Equal(ResponseUsername, response.Username)
+	assert.Equal(ResponseIconUrl, response.IconURL)
+	assert.Equal(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, response.ResponseType)
+	assert.Equal(ErrorTokenMissmatch, response.Text)
+}
+
+func TestHeaderMediaTypeWrong(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	message := "What do you gys wanna grab for lunch?"
+	emojis := ":pizza: :sushi:"
+	err := setConfig("sample_conf.json")
+	require.Nil(err)
+
+	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", Conf.Token, model.NewId(), message, emojis)
+	reader := strings.NewReader(payload)
+	r, err := http.NewRequest("POST", "localhost:8505/poll", reader)
+	require.Nil(err)
+	require.NotNil(r)
+
+	recorder := httptest.NewRecorder()
+	PollCmd(recorder, r)
+	assert.Equal(http.StatusUnsupportedMediaType, recorder.Code)
 }
 
 func TestURLFormat(t *testing.T) {
@@ -111,7 +101,7 @@ func TestURLFormat(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	PollCmd(recorder, r)
-	assert.Equal(recorder.Code, http.StatusBadRequest)
+	assert.Equal(http.StatusBadRequest, recorder.Code)
 }
 
 func setConfig(path string) (err error) {
@@ -125,4 +115,19 @@ func setConfig(path string) (err error) {
 	}
 	Conf = c
 	return nil
+}
+
+func sendHttpRequest(require *require.Assertions, payload string) (response *model.CommandResponse) {
+	reader := strings.NewReader(payload)
+
+	r, err := http.NewRequest(http.MethodPost, "localhost:8505/poll", reader)
+	require.Nil(err)
+	require.NotNil(r)
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	recorder := httptest.NewRecorder()
+	PollCmd(recorder, r)
+	response = model.CommandResponseFromJson(recorder.Result().Body)
+	require.NotNil(response)
+	return
 }

--- a/poll/poll_request.go
+++ b/poll/poll_request.go
@@ -7,7 +7,6 @@ import (
 )
 
 type PollRequest struct {
-	TeamId    string
 	ChannelId string
 	Token     string
 	Message   string
@@ -15,32 +14,32 @@ type PollRequest struct {
 }
 
 const (
-	back_tick          = "`"
-	error_wrong_format = `Wrong message format. Try this instead: ` + back_tick + `/poll \"What do you gys wanna grab for lunch?\" :pizza: :sushi:` + back_tick
+	backTick             = "`"
+	ErrorTextWrongFormat = `The message format is wrong. Try this instead: ` + backTick + `/poll \"What do you gys wanna grab for lunch?\" :pizza: :sushi:` + backTick
+	ErrorTokenMissmatch  = `An error occurred. Ask your administrator to check the Matterpoll config settings.`
+	ErrorWrongLength     = `An error occurred. Try the same command again. If it fails again, contact your administrator.`
 )
 
 func NewPollRequest(u map[string][]string) (*PollRequest, error) {
 	p := &PollRequest{}
 	for key, values := range u {
 		switch key {
-		case "team_id":
-			if p.TeamId = values[0]; len(p.TeamId) == 0 {
-				return nil, fmt.Errorf("Unexpected Error: TeamID in request is empty.")
-			}
 		case "channel_id":
-			if p.ChannelId = values[0]; len(p.ChannelId) == 0 {
-				return nil, fmt.Errorf("Unexpected Error: ChannelID in request is empty.")
+			if err := checkIdLength(values[0]); err != nil {
+				return nil, err
 			}
+			p.ChannelId = values[0]
 		case "token":
-			if p.Token = values[0]; len(p.Token) == 0 {
-				return nil, fmt.Errorf("Unexpected Error: Token in request is empty.")
+			if err := checkIdLength(values[0]); err != nil {
+				return nil, err
 			}
+			p.Token = values[0]
 		case "text":
-			var err error
-			p.Message, p.Emojis, err = parseText(values[0])
+			message, emojis, err := parseText(values[0])
 			if err != nil {
 				return nil, err
 			}
+			p.Message, p.Emojis = message, emojis
 		}
 	}
 	return p, nil
@@ -56,11 +55,11 @@ func parseText(text string) (string, []string, error) {
 	case '"':
 		re = regexp.MustCompile("\"([^\"]+)\"(.+)")
 	default:
-		return "", nil, fmt.Errorf(error_wrong_format)
+		return "", nil, fmt.Errorf(ErrorTextWrongFormat)
 	}
 	e := re.FindStringSubmatch(text)
 	if len(e) != 3 {
-		return "", nil, fmt.Errorf(error_wrong_format)
+		return "", nil, fmt.Errorf(ErrorTextWrongFormat)
 	}
 	var emojis []string
 	for _, v := range strings.Split(e[2], " ") {
@@ -68,9 +67,16 @@ func parseText(text string) (string, []string, error) {
 			continue
 		}
 		if len(v) < 3 || !strings.HasPrefix(v, ":") || !strings.HasSuffix(v, ":") {
-			return "", nil, fmt.Errorf(error_wrong_format, v)
+			return "", nil, fmt.Errorf(ErrorTextWrongFormat, v)
 		}
 		emojis = append(emojis, v[1:len(v)-1])
 	}
 	return e[1], emojis, nil
+}
+
+func checkIdLength(id string) error {
+	if len(id) != 26 {
+		return fmt.Errorf(ErrorWrongLength)
+	}
+	return nil
 }

--- a/poll/poll_request.go
+++ b/poll/poll_request.go
@@ -67,7 +67,7 @@ func parseText(text string) (string, []string, error) {
 			continue
 		}
 		if len(v) < 3 || !strings.HasPrefix(v, ":") || !strings.HasSuffix(v, ":") {
-			return "", nil, fmt.Errorf(ErrorTextWrongFormat, v)
+			return "", nil, fmt.Errorf(ErrorTextWrongFormat)
 		}
 		emojis = append(emojis, v[1:len(v)-1])
 	}

--- a/poll/poll_request_test.go
+++ b/poll/poll_request_test.go
@@ -1,6 +1,7 @@
 package poll
 
 import (
+	"github.com/mattermost/platform/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -10,7 +11,6 @@ func TestNewPollRequest(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	tests := []struct {
-		TeamId      string
 		ChannelId   string
 		Token       string
 		Text        string
@@ -18,35 +18,33 @@ func TestNewPollRequest(t *testing.T) {
 		Emojis      []string
 		ShouldError bool
 	}{
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description` :emoji1:", "description", []string{"emoji1"}, false},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "'description' :emoji1:", "description", []string{"emoji1"}, false},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "\"description\" :emoji1:", "description", []string{"emoji1"}, false},
+		{model.NewId(), model.NewId(), "`description` :emoji1:", "description", []string{"emoji1"}, false},
+		{model.NewId(), model.NewId(), "'description' :emoji1:", "description", []string{"emoji1"}, false},
+		{model.NewId(), model.NewId(), "\"description\" :emoji1:", "description", []string{"emoji1"}, false},
 
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description including space` :emoji1: :emoji2: :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "'description including space' :emoji1: :emoji2: :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "\"description including space\" :emoji1: :emoji2: :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
+		{model.NewId(), model.NewId(), "`description including space` :emoji1: :emoji2: :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
+		{model.NewId(), model.NewId(), "'description including space' :emoji1: :emoji2: :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
+		{model.NewId(), model.NewId(), "\"description including space\" :emoji1: :emoji2: :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
 
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description including space` :emoji1:  :emoji2:   :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
+		{model.NewId(), model.NewId(), "`description including space` :emoji1:  :emoji2:   :emoji3:", "description including space", []string{"emoji1", "emoji2", "emoji3"}, false},
 
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "description including space` :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description including space :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
+		{model.NewId(), model.NewId(), "description including space` :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
+		{model.NewId(), model.NewId(), "`description including space :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
 
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description including space' :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "'description including space\" :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "\"description including space` :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
+		{model.NewId(), model.NewId(), "`description including space' :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
+		{model.NewId(), model.NewId(), "'description including space\" :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
+		{model.NewId(), model.NewId(), "\"description including space` :emoji1: :emoji2: :emoji3:", "", []string{""}, true},
 
-		{"", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description` :emoji1:", "", []string{}, true},
-		{"teamidxxxx", "", "9jrxak1ykxrmnaed9cps9i4cim", "`description` :emoji1:", "", []string{}, true},
-		{"teamidxxxx", "channelidxxxx", "", "`description` :emoji1:", "", []string{}, true},
+		{"", model.NewId(), "`description` :emoji1:", "", []string{}, true},
+		{model.NewId(), "", "`description` :emoji1:", "", []string{}, true},
 
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description including space`", "", []string{}, true},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`description including space` emoji1", "", []string{}, true},
-		{"teamidxxxx", "channelidxxxx", "9jrxak1ykxrmnaed9cps9i4cim", "`` :emoji1:", "", []string{""}, true},
+		{model.NewId(), model.NewId(), "`description including space`", "", []string{}, true},
+		{model.NewId(), model.NewId(), "`description including space` emoji1", "", []string{}, true},
+		{model.NewId(), model.NewId(), "`` :emoji1:", "", []string{""}, true},
 	}
 
 	for _, test := range tests {
 		s := make(map[string][]string)
-		s["team_id"] = []string{test.TeamId}
 		s["channel_id"] = []string{test.ChannelId}
 		s["token"] = []string{test.Token}
 		s["text"] = []string{test.Text}
@@ -59,11 +57,10 @@ func TestNewPollRequest(t *testing.T) {
 			assert.Nil(err)
 			require.NotNil(p)
 
-			assert.Equal(p.TeamId, test.TeamId)
-			assert.Equal(p.ChannelId, test.ChannelId)
-			assert.Equal(p.Token, test.Token)
-			assert.Equal(p.Message, test.Message)
-			assert.Equal(p.Emojis, test.Emojis)
+			assert.Equal(test.ChannelId, p.ChannelId)
+			assert.Equal(test.Token, p.Token)
+			assert.Equal(test.Message, p.Message)
+			assert.Equal(test.Emojis, p.Emojis)
 		}
 	}
 }


### PR DESCRIPTION
While fixing these two issues, I encountered a couple of  small problems like code style and badly written tests. It also gets rid of teams ids.
Fixes #58 
Fixes #47 