### PR TITLE
set content-type to command response

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	ps := poll.Server{c}
+	ps := poll.Server{Conf: c}
 	http.HandleFunc("/poll", ps.Cmd)
 	if err := http.ListenAndServe(c.Listen, nil); err != nil {
 		log.Fatal(err)

--- a/poll/poll_func.go
+++ b/poll/poll_func.go
@@ -53,6 +53,8 @@ func (ps Server) Cmd(w http.ResponseWriter, r *http.Request) {
 		response.ResponseType = model.COMMAND_RESPONSE_TYPE_EPHEMERAL
 		response.Text = err.Error()
 	}
+
+	w.Header().Add("Content-Type", "application/json")
 	if _, err := io.WriteString(w, response.ToJson()); err != nil {
 		log.Print(err)
 		return

--- a/poll/poll_func_test.go
+++ b/poll/poll_func_test.go
@@ -21,11 +21,12 @@ func TestCommandCorrect(t *testing.T) {
 	emojis := ":pizza: :sushi:"
 	c, err := getConfig("sample_conf.json")
 	require.Nil(err)
-	ps := poll.Server{c}
+	ps := poll.Server{Conf: c}
 
 	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", c.Token, model.NewId(), message, emojis)
-	response := sendHttpRequest(require, &ps, payload)
+	response, header := sendHttpRequest(require, &ps, payload)
 
+	assert.Equal("application/json", header.Get("Content-Type"))
 	assert.Equal(poll.ResponseUsername, response.Username)
 	assert.Equal(poll.ResponseIconURL, response.IconURL)
 	assert.Equal(model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, response.ResponseType)
@@ -40,11 +41,12 @@ func TestCommandWronMessageFormat(t *testing.T) {
 	emojis := ""
 	c, err := getConfig("sample_conf.json")
 	require.Nil(err)
-	ps := poll.Server{c}
+	ps := poll.Server{Conf: c}
 
 	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", model.NewId(), model.NewId(), message, emojis)
-	response := sendHttpRequest(require, &ps, payload)
+	response, header := sendHttpRequest(require, &ps, payload)
 
+	assert.Equal("application/json", header.Get("Content-Type"))
 	assert.Equal(poll.ResponseUsername, response.Username)
 	assert.Equal(poll.ResponseIconURL, response.IconURL)
 	assert.Equal(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, response.ResponseType)
@@ -59,11 +61,12 @@ func TestCommandTokenMissmatch(t *testing.T) {
 	emojis := ":pizza: :sushi:"
 	c, err := getConfig("sample_conf.json")
 	require.Nil(err)
-	ps := poll.Server{c}
+	ps := poll.Server{Conf: c}
 
 	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", model.NewId(), model.NewId(), message, emojis)
-	response := sendHttpRequest(require, &ps, payload)
+	response, header := sendHttpRequest(require, &ps, payload)
 
+	assert.Equal("application/json", header.Get("Content-Type"))
 	assert.Equal(poll.ResponseUsername, response.Username)
 	assert.Equal(poll.ResponseIconURL, response.IconURL)
 	assert.Equal(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, response.ResponseType)
@@ -78,7 +81,7 @@ func TestHeaderMediaTypeWrong(t *testing.T) {
 	emojis := ":pizza: :sushi:"
 	c, err := getConfig("sample_conf.json")
 	require.Nil(err)
-	ps := poll.Server{c}
+	ps := poll.Server{Conf: c}
 
 	payload := fmt.Sprintf("token=%s&channel_id=%s&text=\"%s\"%s", c.Token, model.NewId(), message, emojis)
 	reader := strings.NewReader(payload)
@@ -97,7 +100,7 @@ func TestURLFormat(t *testing.T) {
 
 	c, err := getConfig("sample_conf.json")
 	require.Nil(err)
-	ps := poll.Server{c}
+	ps := poll.Server{Conf: c}
 
 	payload := "%"
 	reader := strings.NewReader(payload)
@@ -123,7 +126,7 @@ func getConfig(path string) (*poll.Conf, error) {
 	return c, nil
 }
 
-func sendHttpRequest(require *require.Assertions, ps *poll.Server, payload string) (response *model.CommandResponse) {
+func sendHttpRequest(require *require.Assertions, ps *poll.Server, payload string) (response *model.CommandResponse, header http.Header) {
 	reader := strings.NewReader(payload)
 
 	r, err := http.NewRequest(http.MethodPost, "localhost:8505/poll", reader)
@@ -133,6 +136,7 @@ func sendHttpRequest(require *require.Assertions, ps *poll.Server, payload strin
 
 	recorder := httptest.NewRecorder()
 	ps.Cmd(recorder, r)
+	header = recorder.Header()
 	response = model.CommandResponseFromJson(recorder.Result().Body)
 	require.NotNil(response)
 	return


### PR DESCRIPTION
fixes #88

Mattermost had started checking robust command response content-type.
[PLT-7569: More robust command response content-type checking by ccbrown · Pull Request #7411 · mattermost/mattermost-server](https://github.com/mattermost/mattermost-server/pull/7411)

So we set content-type to our response header (and fix `go vet` error "poll.Server composite literal uses unkeyed fields")